### PR TITLE
BREAKING: remove support for .net48 / 472

### DIFF
--- a/ZLab.Discrete/Algorithms/Collision/BBoxCollisionExtensions.cs
+++ b/ZLab.Discrete/Algorithms/Collision/BBoxCollisionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using ZLab.Discrete.Core;
 using ZLab.Discrete.Geometry;
 
 namespace ZLab.Discrete.Algorithms.Collision
@@ -92,7 +91,7 @@ namespace ZLab.Discrete.Algorithms.Collision
             // distance from plane, but without dividing by |n|
             float distNum = Vector3.Dot(n, c - v0);
             // projection radius of the box onto the plane normal (also without dividing by |n|)
-            float r = MathFx.Abs(n.X) * half.X + MathFx.Abs(n.Y) * half.Y + MathFx.Abs(n.Z) * half.Z;
+            float r = MathF.Abs(n.X) * half.X + MathF.Abs(n.Y) * half.Y + MathF.Abs(n.Z) * half.Z;
 
             // small extra safety band to avoid "edge-only" speckling on thin triangles
             if (distNum > r + CONS_PAD || distNum < -r - CONS_PAD)
@@ -114,7 +113,7 @@ namespace ZLab.Discrete.Algorithms.Collision
             float d21 = Vector3.Dot(vp, e1);
 
             float denom = d00 * d11 - d01 * d01;
-            if (MathFx.Abs(denom) < 1e-20f) return false; // nearly collinear
+            if (MathF.Abs(denom) < 1e-20f) return false; // nearly collinear
 
             float v = (d11 * d20 - d01 * d21) / denom;
             float w = (d00 * d21 - d01 * d20) / denom;
@@ -142,8 +141,8 @@ namespace ZLab.Discrete.Algorithms.Collision
             // Project triangle onto axis L = (0, -aZ, aY)
             float p0 = aZ * v0.Y - aY * v0.Z;
             float p2 = aZ * v2.Y - aY * v2.Z;
-            float min = MathFx.Min(p0, p2), max = MathFx.Max(p0, p2);
-            float r = MathFx.Abs(aZ) * h.Y + MathFx.Abs(aY) * h.Z + SAT_EPS;
+            float min = MathF.Min(p0, p2), max = MathF.Max(p0, p2);
+            float r = MathF.Abs(aZ) * h.Y + MathF.Abs(aY) * h.Z + SAT_EPS;
             return !(min > r || max < -r);
         }
 
@@ -154,8 +153,8 @@ namespace ZLab.Discrete.Algorithms.Collision
             // L = (aZ, 0, -aX)
             float p0 = -aZ * v0.X + aX * v0.Z;
             float p2 = -aZ * v2.X + aX * v2.Z;
-            float min = MathFx.Min(p0, p2), max = MathFx.Max(p0, p2);
-            float r = MathFx.Abs(aZ) * h.X + MathFx.Abs(aX) * h.Z + SAT_EPS;
+            float min = MathF.Min(p0, p2), max = MathF.Max(p0, p2);
+            float r = MathF.Abs(aZ) * h.X + MathF.Abs(aX) * h.Z + SAT_EPS;
             return !(min > r || max < -r);
         }
 
@@ -166,8 +165,8 @@ namespace ZLab.Discrete.Algorithms.Collision
             // L = (-aY, aX, 0)
             float p1 = aY * v1.X - aX * v1.Y;
             float p2 = aY * v2.X - aX * v2.Y;
-            float min = MathFx.Min(p1, p2), max = MathFx.Max(p1, p2);
-            float r = MathFx.Abs(aY) * h.X + MathFx.Abs(aX) * h.Y + SAT_EPS;
+            float min = MathF.Min(p1, p2), max = MathF.Max(p1, p2);
+            float r = MathF.Abs(aY) * h.X + MathF.Abs(aX) * h.Y + SAT_EPS;
             return !(min > r || max < -r);
         }
 

--- a/ZLab.Discrete/Algorithms/Collision/FloodFill.cs
+++ b/ZLab.Discrete/Algorithms/Collision/FloodFill.cs
@@ -2,7 +2,6 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using ZLab.Discrete.Core;
 using ZLab.Discrete.Grids;
 using ZLab.Discrete.Voxels;
 
@@ -29,7 +28,7 @@ namespace ZLab.Discrete.Algorithms.Collision
             Array.Clear(visited, 0, wordCount);
 
             // Queue of linear indices
-            int initialCapacity = MathFx.Clamp(nx * ny, 1 << 16, total);
+            int initialCapacity = Math.Clamp(nx * ny, 1 << 16, total);
             int[] qbuf = ArrayPool<int>.Shared.Rent(initialCapacity);
             RingQueue q = new(qbuf, initialCapacity, total);
 

--- a/ZLab.Discrete/Algorithms/DistanceTransforms/Sdf2D.cs
+++ b/ZLab.Discrete/Algorithms/DistanceTransforms/Sdf2D.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using ZLab.Discrete.Core;
 
 namespace ZLab.Discrete.Algorithms.DistanceTransforms
 {
@@ -48,8 +47,8 @@ namespace ZLab.Discrete.Algorithms.DistanceTransforms
             float[] sdf = new float[width * height];
             for (int i = 0; i < sdf.Length; i++)
             {
-                float distToForeground = MathFx.Sqrt(squaredToForeground[i]);
-                float distToBackground = MathFx.Sqrt(squaredToBackground[i]);
+                float distToForeground = MathF.Sqrt(squaredToForeground[i]);
+                float distToBackground = MathF.Sqrt(squaredToBackground[i]);
                 sdf[i] = distToBackground - distToForeground; // > 0 outside, < 0 inside
             }
             return sdf;

--- a/ZLab.Discrete/Algorithms/DistanceTransforms/Sdf3D.cs
+++ b/ZLab.Discrete/Algorithms/DistanceTransforms/Sdf3D.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Buffers;
-using ZLab.Discrete.Core;
 
 namespace ZLab.Discrete.Algorithms.DistanceTransforms
 {

--- a/ZLab.Discrete/Algorithms/Sampling/DistanceGridSamplingExtension.cs
+++ b/ZLab.Discrete/Algorithms/Sampling/DistanceGridSamplingExtension.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Text;
 using ZLab.Discrete.Core;
 using ZLab.Discrete.Grids;
 
@@ -46,9 +44,9 @@ namespace ZLab.Discrete.Algorithms.Sampling
             Vector3 cellMinWorld = GridConverter.IndexToMinCorner(cellX0, cellY0, cellZ0, vSize, originWorld);
 
             // clamp offset within the cell to [0,1]
-            float fracX = singleX ? 0f : MathFx.Clamp((worldPos.X - cellMinWorld.X) / vSize.X, 0f, 1f);
-            float fracY = singleY ? 0f : MathFx.Clamp((worldPos.Y - cellMinWorld.Y) / vSize.Y, 0f, 1f);
-            float fracZ = singleZ ? 0f : MathFx.Clamp((worldPos.Z - cellMinWorld.Z) / vSize.Z, 0f, 1f);
+            float fracX = singleX ? 0f : Math.Clamp((worldPos.X - cellMinWorld.X) / vSize.X, 0f, 1f);
+            float fracY = singleY ? 0f : Math.Clamp((worldPos.Y - cellMinWorld.Y) / vSize.Y, 0f, 1f);
+            float fracZ = singleZ ? 0f : Math.Clamp((worldPos.Z - cellMinWorld.Z) / vSize.Z, 0f, 1f);
 
             // Convert local indices to global grid indices
             int gx0 = meta.MinX + cellX0;
@@ -174,7 +172,7 @@ namespace ZLab.Discrete.Algorithms.Sampling
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int ClampOrThrow(int value, int min, int max, bool clamp)
         {
-            if (clamp) return MathFx.Clamp(value, min, max);
+            if (clamp) return Math.Clamp(value, min, max);
             if (value < min || value > max)
                 throw new ArgumentOutOfRangeException(nameof(value), "Position is outside the grid bounds.");
             return value;

--- a/ZLab.Discrete/Core/MathFx.cs
+++ b/ZLab.Discrete/Core/MathFx.cs
@@ -8,64 +8,6 @@ namespace ZLab.Discrete.Core
     /// </summary>
     internal static class MathFx
     {
-#if NETFRAMEWORK
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Sqrt(float x) => (float)Math.Sqrt(x);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Abs(float x) => Math.Abs(x);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Min(float a, float b) => Math.Min(a, b);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Max(float a, float b) => Math.Max(a, b);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Floor(float x) => (float)Math.Floor(x);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Ceiling(float x) => (float)Math.Ceiling(x);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Clamp(float value, float min, float max)
-        {
-            if (min > max) { (min, max) = (max, min); }
-            return value < min ? min : (value > max ? max : value);
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Clamp(int value, int min, int max)
-        {
-            if (min > max) { (min, max) = (max, min); }
-            return value < min ? min : (value > max ? max : value);
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Round(float input) => (float)Math.Round(input);
-
-#else
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Sqrt(float x) => MathF.Sqrt(x);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Abs(float x)  => MathF.Abs(x);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Min(float a, float b) => MathF.Min(a, b);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Max(float a, float b) => MathF.Max(a, b);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Floor(float x) => MathF.Floor(x);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Ceiling(float x) => MathF.Ceiling(x);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Clamp(int value, int min, int max)
-        {
-            if (min > max) { (min, max) = (max, min); }
-            return Math.Clamp(value, min, max);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Clamp(float value, float min, float max)
-        {
-            if (min > max) { (min, max) = (max, min); }
-            return Math.Clamp(value, min, max);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Round(float input) => MathF.Round(input);
-#endif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Lerp(float a, float b, float t) => a + t * (b - a);
     }

--- a/ZLab.Discrete/Grids/DistanceGrid.cs
+++ b/ZLab.Discrete/Grids/DistanceGrid.cs
@@ -128,12 +128,7 @@ namespace ZLab.Discrete.Grids
         /// </summary>
         public void Fill(float value)
         {
-#if NETFRAMEWORK
-            for (int i = 0; i < _distances.Length; i++)
-                _distances[i] = value;
-#else
             Array.Fill(_distances, value);
-#endif
         }
 
         /// <summary>

--- a/ZLab.Discrete/Grids/GridConverter.cs
+++ b/ZLab.Discrete/Grids/GridConverter.cs
@@ -1,6 +1,6 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using System.Runtime.CompilerServices;
-using ZLab.Discrete.Core;
 
 namespace ZLab.Discrete.Grids
 {
@@ -18,18 +18,18 @@ namespace ZLab.Discrete.Grids
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static (int x, int y, int z) WorldToGridMin(Vector3 p, Vector3 size)
-            => ((int)MathFx.Floor((p.X + Eps) / size.X),
-                (int)MathFx.Floor((p.Y + Eps) / size.Y),
-                (int)MathFx.Floor((p.Z + Eps) / size.Z));
+            => ((int)MathF.Floor((p.X + Eps) / size.X),
+                (int)MathF.Floor((p.Y + Eps) / size.Y),
+                (int)MathF.Floor((p.Z + Eps) / size.Z));
 
         /// <summary>
         /// World -> grid (min-corner cell index) given a world-space grid origin (min corner) for local grids
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static (int x, int y, int z) WorldToGridMin(Vector3 p, Vector3 size, Vector3 origin)
-            => ((int)MathFx.Floor((p.X - origin.X + Eps) / size.X),
-                (int)MathFx.Floor((p.Y - origin.Y + Eps) / size.Y),
-                (int)MathFx.Floor((p.Z - origin.Z + Eps) / size.Z));
+            => ((int)MathF.Floor((p.X - origin.X + Eps) / size.X),
+                (int)MathF.Floor((p.Y - origin.Y + Eps) / size.Y),
+                (int)MathF.Floor((p.Z - origin.Z + Eps) / size.Z));
 
         // --------------------------- World to Max conversions ---------------------------
         /// <summary>
@@ -38,18 +38,18 @@ namespace ZLab.Discrete.Grids
         /// <remarks>Use this for the MAX CORNER when you want an inclusive index</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static (int x, int y, int z) WorldToGridMaxInclusive(Vector3 p, Vector3 size)
-            => ((int)MathFx.Floor((p.X - Eps) / size.X),
-                (int)MathFx.Floor((p.Y - Eps) / size.Y),
-                (int)MathFx.Floor((p.Z - Eps) / size.Z));
+            => ((int)MathF.Floor((p.X - Eps) / size.X),
+                (int)MathF.Floor((p.Y - Eps) / size.Y),
+                (int)MathF.Floor((p.Z - Eps) / size.Z));
 
         /// <summary>
         /// World -> grid (max-corner cell index, inclusive) given a world-space grid origin (min corner) for local grids
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static (int x, int y, int z) WorldToGridMaxInclusive(Vector3 p, Vector3 size, Vector3 origin)
-            => ((int)MathFx.Floor((p.X - origin.X - Eps) / size.X),
-                (int)MathFx.Floor((p.Y - origin.Y - Eps) / size.Y),
-                (int)MathFx.Floor((p.Z - origin.Z - Eps) / size.Z));
+            => ((int)MathF.Floor((p.X - origin.X - Eps) / size.X),
+                (int)MathF.Floor((p.Y - origin.Y - Eps) / size.Y),
+                (int)MathF.Floor((p.Z - origin.Z - Eps) / size.Z));
         // --------------------------- Index to Min conversions ---------------------------
         /// <summary>
         /// Grid index -> world min corner with origin

--- a/ZLab.Discrete/Grids/OccupancyGrid.cs
+++ b/ZLab.Discrete/Grids/OccupancyGrid.cs
@@ -164,12 +164,7 @@ namespace ZLab.Discrete.Grids
         /// <param name="value">value to fill</param>
         public void Fill(Occupancy value)
         {
-#if NETFRAMEWORK
-            for (int i = 0; i < _occupancies.Length; i++)
-                _occupancies[i] = value;
-#else
             Array.Fill(_occupancies, value);
-#endif
         }
 
         /// <summary>
@@ -275,12 +270,7 @@ namespace ZLab.Discrete.Grids
 
             Occupancy[] next = new Occupancy[_occupancies.Length];
             // prefill with outside
-#if NETFRAMEWORK
-            for (int i = 0; i < next.Length; i++)
-                next[i] = Occupancy.Outside;
-#else
             Array.Fill(next, Occupancy.Outside);
-#endif
 
             // compute source range that remain in bounds after shift by (dx,dy,dz)
             // copy from src -> dst where dst = src + (dx,dy,dz)

--- a/ZLab.Discrete/Operations/Meshing/DiscreteMesher.cs
+++ b/ZLab.Discrete/Operations/Meshing/DiscreteMesher.cs
@@ -2,11 +2,8 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using ZLab.Discrete.Algorithms.Encoding;
-using ZLab.Discrete.Core;
 using ZLab.Discrete.Geometry;
-using ZLab.Discrete.Voxels;
 
 namespace ZLab.Discrete.Operations.Meshing
 {
@@ -328,9 +325,9 @@ namespace ZLab.Discrete.Operations.Meshing
             for (int i = 0; i < origins.Length; i++)
             {
                 Vector3 v = origins[i];
-                var (ix, iy, iz) = ToIdx(v, minCorner, inv);
+                (int ix, int iy, int iz) = ToIdx(v, minCorner, inv);
 
-                foreach (var n in N6)
+                foreach ((int dx, int dy, int dz, Vector3 dir) n in N6)
                 {
                     int nx = ix + n.dx, ny = iy + n.dy, nz = iz + n.dz;
                     // Out-of-range neighbors should be treated as empty (face visible).
@@ -373,9 +370,9 @@ namespace ZLab.Discrete.Operations.Meshing
             float fx = (p.X - min.X) * inv.X;
             float fy = (p.Y - min.Y) * inv.Y;
             float fz = (p.Z - min.Z) * inv.Z;
-            int ix = (int)MathFx.Round(fx + (fx >= 0 ? eps : -eps));
-            int iy = (int)MathFx.Round(fy + (fy >= 0 ? eps : -eps));
-            int iz = (int)MathFx.Round(fz + (fz >= 0 ? eps : -eps));
+            int ix = (int)MathF.Round(fx + (fx >= 0 ? eps : -eps));
+            int iy = (int)MathF.Round(fy + (fy >= 0 ? eps : -eps));
+            int iz = (int)MathF.Round(fz + (fz >= 0 ? eps : -eps));
             return (ix, iy, iz);
         }
 

--- a/ZLab.Discrete/Operations/Rasterizing/SparseRasterizer.cs
+++ b/ZLab.Discrete/Operations/Rasterizing/SparseRasterizer.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
-using ZLab.Discrete.Core;
 using ZLab.Discrete.Geometry;
 using ZLab.Discrete.Voxels;
 
@@ -19,9 +18,9 @@ namespace ZLab.Discrete.Operations.Rasterizing
         }
 
         private (int ix, int iy, int iz) Q(Vector3 v)
-            => ((int)MathFx.Round(v.X * _inv.X),
-                (int)MathFx.Round(v.Y * _inv.Y),
-                (int)MathFx.Round(v.Z * _inv.Z));
+            => ((int)MathF.Round(v.X * _inv.X),
+                (int)MathF.Round(v.Y * _inv.Y),
+                (int)MathF.Round(v.Z * _inv.Z));
 
         public bool Equals(Vector3 a, Vector3 b) => Q(a) == Q(b);
 

--- a/ZLab.Discrete/ZLab.Discrete.csproj
+++ b/ZLab.Discrete/ZLab.Discrete.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net7.0;net8.0;net9.0;net48;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net7.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <PackageId>$(AssemblyName)</PackageId>
@@ -24,9 +24,7 @@
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
-  <ItemGroup Condition=" $([System.String]::Copy('$(TargetFramework)').StartsWith('net4')) ">
-    <PackageReference Include="System.Memory" Version="4.6.3" />
-  </ItemGroup>  <ItemGroup>
+  <ItemGroup>
     <None Include="..\docs\icons\128w\dark.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
@@ -39,5 +37,8 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Core\" />
   </ItemGroup>
 </Project>

--- a/docs/docfx/index.md
+++ b/docs/docfx/index.md
@@ -42,8 +42,6 @@ A fully managed .NET library for voxelization, meshing, and distance field compu
 
 
 ## Supported Frameworks
-- .NET Framework 4.7.2
-- .NET Framework 4.8
 - .NET Standard 2.1
 - .NET 7.0
 - .NET 8.0

--- a/readme.md
+++ b/readme.md
@@ -42,8 +42,6 @@ A fully managed .NET library for voxelization, meshing, and distance field compu
 
 
 ## Supported Frameworks
-- .NET Framework 4.7.2
-- .NET Framework 4.8
 - .NET Standard 2.1
 - .NET 7.0
 - .NET 8.0


### PR DESCRIPTION
BREAKING: remove support for .net48 / 472

Remove support .netframework 4.8.0 & .netframework 4.7.2 due to this frame work is largely out of support, and does not support cross platform.

Development with older framework like .net4 increases development time & methods might suffer performance degredation due to consideration with backward compatabilities.